### PR TITLE
Remove CloudPebble vs SDK specific blocks in content

### DIFF
--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -225,27 +225,6 @@ release.
 {% endalert %}
 ```
 
-### SDK Platform Specific Paragraphs
-
-On pages that have the SDK Platform choice system, you can tag paragraphs as
-being only relevant for CloudPebble or local SDK users. Text, code snippets,
-images, and other markdown are all supported.
-
-First, add `platform_choice: true` to the page YAML metadata.
-
-Specify platform-specific sections of markdown using the `platform` Liquid tag:
-
-```
-{% platform local %}
-Add the resource to your project in `package.json`.
-{% endplatform %}
-
-{% platform cloudpebble %}
-Add the resource to your project by clicking 'Add New' next to 'Resources' in
-the project sidebar.
-{% endplatform %}
-```
-
 ### Formatting
 
 The following additional text formatting syntax is supported.

--- a/source/_guides/app-resources/animated-images.md
+++ b/source/_guides/app-resources/animated-images.md
@@ -19,7 +19,6 @@ description: |
   display them in your app.
 guide_group: app-resources
 order: 0
-platform_choice: true
 ---
 
 The Pebble SDK allows animated images to be played inside an app using the
@@ -47,7 +46,6 @@ A `.gif` file can be converted to the APNG `.png` format with
 
 ## Adding an APNG
 
-{% platform local %}
 Include the APNG file in the `resources` array in `package.json` as a `raw`
 resource:
 
@@ -62,12 +60,6 @@ resource:
   ]
 }
 ```
-{% endplatform %}
-
-{% platform cloudpebble %}
-To add the APNG file as a raw resource, click 'Add New' in the Resources section
-of the sidebar, and set the 'Resource Type' as 'raw binary blob'.
-{% endplatform %}
 
 ## Displaying APNG Frames
 

--- a/source/_guides/app-resources/fonts.md
+++ b/source/_guides/app-resources/fonts.md
@@ -18,7 +18,6 @@ description: |
   How to use built-in system fonts, or add your own font resources to a project.
 guide_group: app-resources
 order: 3
-platform_choice: true
 ---
 
 
@@ -77,7 +76,6 @@ graphics_draw_text(ctx, text, fonts_get_system_font(FONT_KEY_GOTHIC_24), bounds,
 
 ## Adding a Custom Font
 
-{% platform local %}
 After placing the font file in the project's `resources` directory, the custom
 font can be added to a project as `font` `type` item in the `media` array in
 `package.json`. The `name` field's contents will be made available at compile
@@ -95,18 +93,6 @@ For example:
   ]
 }
 ```
-{% endplatform %}
-
-{% platform cloudpebble %}
-To add a custom font file to your project, click 'Add New' in the Resources
-section of the sidebar. Set the 'Resource Type' to 'TrueType font', and upload
-the file using the 'Choose file' button. Choose an 'Identifier', which will be
-made available at compile time with `RESOURCE_ID_` at the front. This must end
-with the desired font size ("EXAMPLE_FONT_20", for example).
-
-Configure the other options as appropriate, then hit 'Save' to save the
-resource.
-{% endplatform %}
 
 {% alert important %}
 The maximum recommended font size is 48.
@@ -180,13 +166,6 @@ font character sets in common watchapp scenarios:
 | `[0-9:A-Za-z° ]` | Time, date, and degree symbol for temperature gauges. |
 | `[0-9°CF ]` | Numbers and degree symbol with 'C' and 'F' for temperature gauges. |
 
-{% platform cloudpebble %}
-Open the font's configuration screen under 'Resources', then enter the desired
-regex in the 'Characters' field. Check the preview of the new set of characters,
-then choose 'Save'.
-{% endplatform %}
-
-{% platform local %}
 Add the `characterRegex` key to any font objects in `package.json`'s
 `media` array.
 
@@ -200,7 +179,6 @@ Add the `characterRegex` key to any font objects in `package.json`'s
   }
 ]
 ```
-{% endplatform %}
 
 Check out
 [regular-expressions.info](http://www.regular-expressions.info/tutorial.html)

--- a/source/_guides/app-resources/images.md
+++ b/source/_guides/app-resources/images.md
@@ -18,7 +18,6 @@ description: |
   How to add image resources to a project and display them in your app.
 guide_group: app-resources
 order: 4
-platform_choice: true
 ---
 
 Images can be displayed in a Pebble app by adding them as a project resource.
@@ -57,13 +56,6 @@ are available below. Use these when creating color image resources:
 
 ## Import the Image
 
-{% platform cloudpebble %}
-Add the `.png` file as a resource using the 'Add New' button next to
-'Resources'. Give the resource a suitable 'Identifier' such as 'EXAMPLE_IMAGE'
-and click 'Save'.
-{% endplatform %}
-
-{% platform local %}
 After placing the image in the project's `resources` directory, add an entry to
 the `resources` item in `package.json`. Specify the `type` as `bitmap`, choose a
 `name` (to be used in code) and supply the path relative to the project's
@@ -80,7 +72,6 @@ the `resources` item in `package.json`. Specify the `type` as `bitmap`, choose a
   ]
 },
 ```
-{% endplatform %}
 
 
 ## Specifying an Image Resource
@@ -96,13 +87,6 @@ Resources of this type can be optimized using additional attributes:
 | `storageFormat` | Optional. Determines the file format used for storage. Using `spaceOptimization` instead is preferred. | `pbi` or `png`. |
 | `spaceOptimization` | Optional. Determines whether the output resource is optimized for low runtime memory or low resource space usage. | `storage` or `memory`. |
 
-{% platform cloudpebble %}
-These attributes can be selected in CloudPebble from the resource's page:
-
-![](/images/guides/app-resources/cp-bitmap-attributes.png)
-{% endplatform %}
-
-{% platform local %}
 An example usage of these attributes in `package.json` is shown below:
 
 ```js
@@ -114,7 +98,6 @@ An example usage of these attributes in `package.json` is shown below:
   "spaceOptimization": "memory"
 }
 ```
-{% endplatform %}
 
 On all platforms `memoryFormat` will default to `Smallest`. On Aplite
 `spaceOptimization` will default to `memory`, and `storage` on all other
@@ -159,15 +142,8 @@ stored in while the app is running:
 static GBitmap *s_bitmap;
 ```
 
-{% platform cloudpebble %}
-Create the ``GBitmap``, specifying the 'Identifier' chosen earlier, prefixed
-with `RESOURCE_ID_`. This will manage the image data:
-{% endplatform %}
-
-{% platform local %}
 Create the ``GBitmap``, specifying the `name` chosen earlier, prefixed with
 `RESOURCE_ID_`. This will manage the image data:
-{% endplatform %}
 
 ```c
 s_bitmap = gbitmap_create_with_resource(RESOURCE_ID_EXAMPLE_IMAGE);

--- a/source/_guides/app-resources/index.md
+++ b/source/_guides/app-resources/index.md
@@ -21,7 +21,6 @@ menu: false
 permalink: /guides/app-resources/
 generate_toc: false
 hide_comments: true
-platform_choice: true
 ---
 
 The Pebble SDK allows apps to include extra files as app resources. These files
@@ -37,18 +36,10 @@ Aplite platform, and **256 kB** on the Basalt and Chalk platforms. These limits
 include resources used by included Pebble Packages.
 {% endalert %}
 
-{% platform local %}
 App resources are included in a project by being listed in the `media` property
 of `package.json`, and are converted into suitable firmware-compatible formats
 at build time. Examples of this are shown in each type of resource's respective
 guide.
-{% endplatform %}
-
-{% platform cloudpebble %}
-App resources are included in a project by clicking the 'Add New' button under
-'Resources' and specifying the 'Resource Type' as appropriate. These are then
-converted into suitable firmware-compatible formats at build time.
-{% endplatform %}
 
 
 ## Contents

--- a/source/_guides/app-resources/raw-data-files.md
+++ b/source/_guides/app-resources/raw-data-files.md
@@ -18,7 +18,6 @@ description: |
   How to add raw data resources to a project and read them in your app.
 guide_group: app-resources
 order: 7
-platform_choice: true
 ---
 
 Some kinds of apps will require extra data that is not a font or an image. In
@@ -34,7 +33,6 @@ dictionaries, CSV data files, etc.
 
 ## Adding Raw Data Files
 
-{% platform local %}
 To add a file as a raw resource, specify its `type` as `raw` in `package.json`.
 An example is shown below:
 
@@ -49,12 +47,6 @@ An example is shown below:
   ]
 }
 ```
-{% endplatform %}
-
-{% platform cloudpebble %}
-To add a file as a raw resource, click 'Add New' in the Resources section of the
-sidebar, and set the 'Resource Type' as 'raw binary blob'.
-{% endplatform %}
 
 
 ## Reading Bytes and Byte Ranges

--- a/source/_guides/communication/advanced-communication.md
+++ b/source/_guides/communication/advanced-communication.md
@@ -31,7 +31,6 @@ related_examples:
     url: https://github.com/pebble-examples/png-download-example
   - title: Pebble Faces
     url: https://github.com/pebble-examples/pebble-faces
-platform_choice: true
 ---
 
 Many types of connected Pebble watchapps and watchfaces perform common tasks
@@ -52,8 +51,6 @@ code implements the `appmessage` event listsner, it is ready to receive data.
 > for such an event thanks to the `Intent` system. iOS companion apps must wait
 > for `-watchDidConnect:`.
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
 A simple method is to define a key in `package.json` that will be interpreted by
 the watchapp to mean that the JS environment is ready for exchange data:
 
@@ -62,17 +59,6 @@ the watchapp to mean that the JS environment is ready for exchange data:
   "JSReady"
 ]
 ```
-{% endmarkdown %}
-</div>
-
-<div class="platform-specific" data-sdk-platform="cloudpebble">
-{% markdown %}
-A simple method is to define a key in Settings that will be interpreted by
-the watchapp to mean that the JS environment is ready for exchange data:
-
-* JSReady
-{% endmarkdown %}
-</div>
 
 The watchapp should implement a variable that describes if the `ready` event has
 occured. An example is shown below:
@@ -258,20 +244,9 @@ static int s_index = 0;
 
 When a message has been sent, this index is used to construct the next message:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
 > Note: A useful key scheme is to use the item's array index as the key. For
 > PebbleKit JS that number of keys will have to be declared in `package.json`,
 > like so: `someArray[6]`
-{% endmarkdown %}
-</div>
-<div class="platform-specific" data-sdk-platform="cloudpebble">
-{% markdown %}
-> Note: A useful key scheme is to use the item's array index as the key. For
-> PebbleKit JS that number of keys will have to be declared in the project's
-> 'Settings' page, like so: `someArray[6]`
-{% endmarkdown %}
-</div>
 
 ```c
 static void outbox_sent_handler(DictionaryIterator *iter, void *context) {

--- a/source/_guides/communication/index.md
+++ b/source/_guides/communication/index.md
@@ -21,7 +21,6 @@ menu: false
 permalink: /guides/communication/
 generate_toc: false
 hide_comments: true
-platform_choice: true
 ---
 
 All Pebble watchapps and watchfaces have the ability to communicate with the
@@ -76,18 +75,8 @@ iOS.
 All messages sent from a Pebble watchapp or watchface will be delivered to the
 appropriate phone app depending on the layout of the developer's project:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
 * If at least an `index.js` file is present in `src/pkjs/`, the message will be
   handled by PebbleKit JS.
-{% endmarkdown %}
-</div>
-<div class="platform-specific" data-sdk-platform="cloudpebble">
-{% markdown %}
-* If the project contains at least one JavaScript file, the message will be
-  handled by PebbleKit JS.
-{% endmarkdown %}
-</div>
 
 * If there is no valid JS file present (at least an `index.js`) in the project,
   the message will be delivered to the official Pebble mobile app. If there is a

--- a/source/_guides/communication/using-pebblekit-js.md
+++ b/source/_guides/communication/using-pebblekit-js.md
@@ -19,7 +19,6 @@ description: |
   environment.
 guide_group: communication
 order: 4
-platform_choice: true
 ---
 
 PebbleKit JS allows a JavaScript component (run in a sandbox inside the official
@@ -42,13 +41,8 @@ Extra features available to an app using PebbleKit JS include:
 
 ## Setting Up
 
-^LC^ PebbleKit JS can be set up by creating the `index.js` file in the project's
+PebbleKit JS can be set up by creating the `index.js` file in the project's
 `src/pkjs/` directory. Code in this file will be executed when the associated
-watchapp is launched, and will stop once that app exits.
-
-^CP^ PebbleKit JS can be set up by clicking 'Add New' in the Source Files
-section of the sidebar. Choose the 'JavaScript file' type and choose a file name
-before clicking 'Create'. Code in this file will be executed when the associated
 watchapp is launched, and will stop once that app exits.
 
 The basic JS code required to begin using PebbleKit JS is shown below. An event
@@ -78,29 +72,21 @@ to learn how to do this.
 
 ## Defining Keys
 
-^LC^ Before any messages can be sent or received, the keys to be used to store the
+Before any messages can be sent or received, the keys to be used to store the
 data items in the dictionary must be declared. The watchapp side uses
 exclusively integer keys, whereas the JavaScript side may use the same integers
 or named string keys declared in `package.json`. Any string key not declared
 beforehand will not be transmitted to/from Pebble.
 
-^CP^ Before any messages can be sent or received, the keys to be used to store
-the data items in the dictionary must be declared. The watchapp side uses
-exclusively integer keys, whereas the JavaScript side may use the same integers
-or named string keys declared in the 'PebbleKit JS Message Keys' section of
-'Settings'. Any string key not declared beforehand will not be transmitted
-to/from Pebble.
-
 > Note: This requirement is true of PebbleKit JS **only**, and not PebbleKit
 > Android or iOS.
 
-^LC^  Keys are declared in the project's `package.json` file in the `messageKeys`
+Keys are declared in the project's `package.json` file in the `messageKeys`
 object, which is inside the `pebble` object. Example keys are shown as equivalents
 to the ones used in the hypothetical weather app example in
 {% guide_link communication/sending-and-receiving-data#choosing-key-values %}.
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "messageKeys": [
   "Temperature",
   "WindSpeed",
@@ -108,12 +94,7 @@ to the ones used in the hypothetical weather app example in
   "RequestData",
   "LocationName"
 ]
-{% endhighlight %}
-</div>
-
-^CP^ Keys are declared individually in the 'PebbleKit JS Message Keys' section
-of the 'Settings' page. Enter the 'Key Name' of each key that will be used by
-the app.
+```
 
 The names chosen here will be injected into your C code prefixed with `MESSAGE_KEY_`,
 like `MESSAGE_KEY_Temperature`. As such, they must be legal C identifiers.
@@ -299,17 +280,12 @@ PebbleKit JS provides access to the location services provided by the phone
 through the
 [`navigator.geolocation`](http://dev.w3.org/geo/api/spec-source.html) object.
 
-^CP^ Declare that the app will be using the `geolocation` API by checking the
-'Uses Location' checkbox in the 'Settings' screen.
-
-^LC^ Declare that the app will be using the `geolocation` API by adding the
+Declare that the app will be using the `geolocation` API by adding the
 string `location` in the `capabilities` array in `package.json`:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "capabilities": [ "location" ]
-{% endhighlight %}
-</div>
+```
 
 Below is an example showing how to get a single position value from the
 `geolocation` API using the 

--- a/source/_guides/debugging/debugging-with-app-logs.md
+++ b/source/_guides/debugging/debugging-with-app-logs.md
@@ -21,7 +21,6 @@ guide_group: debugging
 order: 1
 related_docs:
   - Logging
-platform_choice: true
 ---
 
 
@@ -90,24 +89,16 @@ Pebble.sendAppMessage({'KEY': value}, function(e) {
 When viewing app logs, both the C and JS files' output are shown in the same
 view.
 
-^CP^ To view app logs in CloudPebble, open a project and navigate to the
-'Compilation' screen. Click 'View App Logs' and run an app that includes log
-output calls to see the output appear in this view.
-
-^LC^ The `pebble` {% guide_link tools-and-resources/pebble-tool %} will
+The `pebble` {% guide_link tools-and-resources/pebble-tool %} will
 output any logs from C and JS files after executing the `pebble logs` command
 and supplying the phone's IP address:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
 ```text
 pebble logs --phone=192.168.1.25
 ```
 
 > Note: You can also use `pebble install --logs' to combine both of these
 > operations into one command.
-{% endmarkdown %}
-</div>
 
 
 ## Memory Usage Information

--- a/source/_guides/events-and-services/background-worker.md
+++ b/source/_guides/events-and-services/background-worker.md
@@ -26,7 +26,6 @@ related_examples:
     url: https://github.com/pebble-examples/feature-background-counter
   - title: Background Worker Communication
     url: https://github.com/pebble-examples/feature-worker-message
-platform_choice: true
 ---
 
 In addition to the main foreground task that every Pebble app implements, a
@@ -60,16 +59,10 @@ worker when compared to those of the foreground task:
 
 ## Adding a Worker
 
-^CP^ The background worker's behavior is determined by code written in a
-separate C file to the foreground app. Add a new source file and set the
-'Target' field to 'Background Worker'.
-
-^LC^ The background worker's behavior is determined by code written in a
+The background worker's behavior is determined by code written in a
 separate C file to the foreground app, created in the `/worker_src` project 
 directory.
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
 This project structure can also be generated using the 
 [`pebble` tool](/guides/tools-and-resources/pebble-tool/) with the `--worker`
 flag as shown below:
@@ -77,8 +70,6 @@ flag as shown below:
 ```bash
 $ pebble new-project --worker project_name
 ```
-{% endmarkdown %}
-</div>
 
 The worker C file itself has a basic structure similar to a regular Pebble app,
 but with a couple of minor changes, as shown below:
@@ -240,9 +231,6 @@ Background workers do not have access to the UI APIs. They also cannot use the
 ``DataLogging``, ``HealthService``, ``ConnectionService``,
 ``BatteryStateService``, ``TickTimerService`` and ``Storage``.
 
-^LC^ The compiler will throw an error if the developer attempts to use an API
+The compiler will throw an error if the developer attempts to use an API
 unsupported by the worker. For a definitive list of available APIs, check
 `pebble_worker.h` in the SDK bundle for the presence of the desired API.
-
-^CP^ CloudPebble users will be notified by the editor and compiler if they
-attempt to use an unavailable API.

--- a/source/_guides/events-and-services/hrm.md
+++ b/source/_guides/events-and-services/hrm.md
@@ -26,7 +26,6 @@ related_examples:
     url: https://github.com/pebble-examples/watchface-tutorial-hrm
   - title: HRM Activity
     url: https://github.com/pebble-examples/hrm-activity-example
-platform_choice: true
 ---
 
 The Pebble Time 2 and Pebble 2 (excluding SE model)
@@ -41,8 +40,6 @@ before proceeding.
 
 ## Enable Health Data
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown {} %}
 Before your application is able to access the heart rate information, you will
 need to add `heath` to the `capabilities` array in your applications
 `package.json` file.
@@ -57,12 +54,6 @@ need to add `heath` to the `capabilities` array in your applications
   }
 }
 ```
-{% endmarkdown %}
-</div>
-
-^CP^ Before your application is able to access heart rate information, you will
-need to enable the `USES HEALTH` option in your project settings on
-[CloudPebble]({{ site.links.cloudpebble }}).
 
 
 ## Data Quality

--- a/source/_guides/graphics-and-animations/vector-graphics.md
+++ b/source/_guides/graphics-and-animations/vector-graphics.md
@@ -18,7 +18,6 @@ description: |
   How to draw simple images using vector images, instead of bitmaps.
 guide_group: graphics-and-animations
 order: 3
-platform_choice: true
 related_docs:
   - Draw Commands
 related_examples:
@@ -85,15 +84,10 @@ created at runtime.
 
 ## Drawing Vector Graphics
 
-^CP^ Add the PDC file as a project resource using the 'Add new' under
-'Resources' on the left-hand side of the CloudPebble editor as a 'raw binary
-blob'.
-
-^LC^ Add the PDC file to the project resources in `package.json` with the
+Add the PDC file to the project resources in `package.json` with the
 'type' field to `raw`:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "media": [
   {
     "type": "raw",
@@ -101,16 +95,10 @@ blob'.
     "file": "example_image.pdc"
   }
 ]
-{% endhighlight %}
-</div>
 
-^LC^ Drawing a Pebble Draw Command image is just as simple as drawing a normal
+Drawing a Pebble Draw Command image is just as simple as drawing a normal
 PNG image to a graphics context, requiring only one draw call. First, load the
 `.pdc` file from resources as shown below.
-
-^CP^ Drawing a Pebble Draw Command image is just as simple as drawing a normal
-PNG image to a graphics context, requiring only one draw call. First, load the
-`.pdc` file from resources, as shown below.
 
 First, declare a pointer of type ``GDrawCommandImage`` at the top of the file:
 

--- a/source/_guides/rocky-js/rocky-js-overview.md
+++ b/source/_guides/rocky-js/rocky-js-overview.md
@@ -19,7 +19,6 @@ description: |
   started.
 guide_group: rocky-js
 order: 1
-platform_choice: true
 related_examples:
  - title: Tutorial Part 1
    url: https://github.com/pebble-examples/rocky-watchface-tutorial-part1
@@ -73,28 +72,17 @@ services, use geolocation, and offload data processing tasks to the phone.
 
 ### Creating a Project
 
-^CP^ Go to [CloudPebble]({{ site.links.cloudpebble }}) and click 'CREATE', enter
-a project name, then select the 'Rocky.js' project type.
-
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown {} %}
 Once you've installed the Pebble SDK, you can create a new Rocky.js project
 using the following command:
 
 ```nc|text
 $ pebble new-project --rocky <strong><em>projectname</em></strong>
 ```
-{% endmarkdown %}
-</div>
 
 
 ### Rocky JS
 
-^CP^ In [CloudPebble]({{ site.links.cloudpebble }}), add a new App Source, the
-file type is JavaScript and the target is `Rocky JS`. `index.js` is now the main
-entry point into the application on the watch.
-
-^LC^ In the local SDK, our main entry point into the application on the watch is
+In the local SDK, our main entry point into the application on the watch is
 `/src/rocky/index.js`.
 
 This is file is where our Rocky.js JavaScript code resides. All code within this
@@ -105,11 +93,7 @@ scripts may also be added, see [below](#additional-scripts).
 
 ### PebbleKit JS
 
-^CP^ In [CloudPebble]({{ site.links.cloudpebble }}), add a new App Source, the
-file type is JavaScript and the target is [PebbleKit JS](/docs/pebblekit-js/).
-This file should be named `index.js`.
-
-^LC^ In the local SDK, our primary [PebbleKit JS](/docs/pebblekit-js/) script is
+In the local SDK, our primary [PebbleKit JS](/docs/pebblekit-js/) script is
 `/src/pkjs/index.js`.
 
 All PebbleKit JS code will execute on the mobile device connected to the
@@ -127,10 +111,7 @@ added, see [below](#additional-scripts).
 If you need to share code between Rocky.js and PebbleKit JS, you can place
 JavaScript files in a shared area.
 
-^CP^ In [CloudPebble]({{ site.links.cloudpebble }}), add a new App Source, the
-file type is JavaScript and the target is `Shared JS`.
-
-^LC^ In the local SDK, place your shared files in `/src/common/`.
+In the local SDK, place your shared files in `/src/common/`.
 
 Shared JavaScript files can be referenced using the
 [CommonJS Module](http://www.commonjs.org/specs/modules/1.0/) format.

--- a/source/_guides/user-interfaces/app-configuration-static.md
+++ b/source/_guides/user-interfaces/app-configuration-static.md
@@ -18,7 +18,6 @@ description: |
   How to allow users to customize an app with a static configuration page.
 guide_group:
 order: 0
-platform_choice: true
 ---
 
 > This guide provides the steps to manually create an app configuration page.
@@ -44,36 +43,25 @@ PebbleKit JS,
 
 ## Adding Configuration
 
-^LC^ For an app to be configurable, it must marked as 'configurable' in the
+For an app to be configurable, it must marked as 'configurable' in the
 app's {% guide_link tools-and-resources/app-metadata "`package.json`" %}
 `capabilities` array. The presence of this value tells the mobile app to
 display a gear icon next to the app, allowing users to access the configuration
 page.
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
-```js
+```json
 "capabilities": [ "configurable" ]
 ```
-{% endmarkdown %}
-</div>
-
-^CP^ For an app to be configurable, it must include the 'configurable' item in
-'Settings'. The presence of this value tells the mobile app to display the
-gear icon that is associated with the ability to launch the config page.
-
 
 
 ## Choosing Key Values
 
-^LC^ Since the config page must transmit the user's preferred options to the
+Since the config page must transmit the user's preferred options to the
 watchapp, the first step is to decide upon the ``AppMessage`` keys defined in
 `package.json` that will be used to represent the chosen value for each option
 on the config page:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
-```js
+```json
 "messageKeys": [
   "BackgroundColor",
   "ForegroundColor",
@@ -81,25 +69,6 @@ on the config page:
   "Animations"
 ]
 ```
-{% endmarkdown %}
-</div>
-
-^CP^ Since the config page must transmit the user's preferred options to the
-watchapp, the first step is to decide upon the ``AppMessage`` keys defined in
-'Settings' that will be used to represent each option on the config page. An
-example set is shown below:
-
-<div class="platform-specific" data-sdk-platform="cloudpebble">
-{% markdown %}
-* `BackgroundColor`
-
-* `ForegroundColor`
-
-* `SecondTick`
-
-* `Animations`
-{% endmarkdown %}
-</div>
 
 These keys will automatically be available both in C on the watch and in
 PebbleKit JS on the phone.

--- a/source/_guides/user-interfaces/app-configuration.md
+++ b/source/_guides/user-interfaces/app-configuration.md
@@ -18,7 +18,6 @@ description: |
   How to allow users to customize an app with a configuration page.
 guide_group: user-interfaces
 order: 0
-platform_choice: true
 related_examples:
   - title: Clay Example
     url: https://github.com/pebble-examples/clay-example
@@ -44,19 +43,12 @@ Internet connection.
 
 ## Enabling Configuration
 
-^LC^ For an app to be configurable, it must include the 'configurable' item in
+For an app to be configurable, it must include the 'configurable' item in
 `package.json`.
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
-```js
+```json
 "capabilities": [ "configurable" ]
 ```
-{% endmarkdown %}
-</div>
-
-^CP^ For an app to be configurable, it must include the 'configurable' item in
-'Settings'.
 
 The presence of this value tells the mobile app to display the gear icon that
 is associated with the ability to launch the config page next to the app itself.
@@ -66,18 +58,11 @@ is associated with the ability to launch the config page next to the app itself.
 Clay is available as a {% guide_link pebble-packages "Pebble Package" %}, so it
 takes minimal effort to install.
 
-^LC^ Within your project folder, just type:
+Within your project folder, just type:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
 ```nc|text
 $ pebble package install pebble-clay
 ```
-{% endmarkdown %}
-</div>
-
-^CP^ Go to the 'Dependencies' tab, type 'pebble-clay' into the search box and
-press 'Enter' to add the dependency.
 
 
 ## Choosing messageKeys
@@ -89,12 +74,10 @@ In this example, we're going to allow users to control the background color,
 foreground color, whether the watchface ticks on seconds and whether any
 animations are displayed.
 
-^LC^ We define `messageKeys` in the `package.json` file for each configuration
+We define `messageKeys` in the `package.json` file for each configuration
 setting in our application:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
-```js
+```json
 "messageKeys": [
   "BackgroundColor",
   "ForegroundColor",
@@ -102,28 +85,13 @@ setting in our application:
   "Animations"
 ]
 ```
-{% endmarkdown %}
-</div>
 
-^CP^ We define `messageKeys` in the 'Settings' tab for each configuration
-setting in our application. The 'Message Key Assignment Kind' should be set to
-'Automatic Assignment', then just enter each key name:
-
-<div class="platform-specific" data-sdk-platform="cloudpebble">
-{% markdown %}
-![CloudPebble Settings](/images/guides/user-interfaces/app-configuration/message-keys.png =400)
-{% endmarkdown %}
-</div>
 
 ## Creating the Clay Configuration
 
-^LC^ The Clay configuration file (`config.js`) should be created in your
+The Clay configuration file (`config.js`) should be created in your
 `src/pkjs/` folder. It allows the easy definition of each type of HTML form
 entity that is required. These types include:
-
-^CP^ The Clay configuration file (`config.js`) needs to be added to your project
-by adding a new 'Javascript' source file. It allows the easy definition of
-each type of HTML form entity that is required. These types include:
 
 * [Section](https://github.com/pebble/clay#section)
 * [Heading](https://github.com/pebble/clay#heading)
@@ -221,14 +189,10 @@ var clayConfig = require('./config');
 var clay = new Clay(clayConfig);
 ```
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown %}
 > When using the local SDK, it is possible to use a pure JSON
 > configuration file (`config.json`). If this is the case, you must not include
 > the `module.exports = []` in your configuration file, and you need to
 > `var clayConfig = require('./config.json');`
-{% endmarkdown %}
-</div>
 
 ## Receiving Config Data
 

--- a/source/_layouts/guides/default.html
+++ b/source/_layouts/guides/default.html
@@ -55,15 +55,7 @@ regenerate: true
       </p>
     </div>
     {% endif %}
-<!-- 
-    {% if page.platform_choice %}
-    {% include platform-choice.html %}
-    {% endif %}
- -->
     <div class="markdown markdown--staff">
-    {% if page.platform_choice %}
-    {% include platform-choice.html %}
-    {% endif %}
     {{ content }}
     </div>
     {% unless page.hide_comments %}

--- a/source/_layouts/guides/wide.html
+++ b/source/_layouts/guides/wide.html
@@ -53,9 +53,6 @@ layout: guides/master
       </p>
     </div>
     {% endif %}
-    {% if page.platform_choice %}
-    {% include platform-choice.html %}
-    {% endif %}
     <div>{{ content }}</div>
     {% unless page.hide_comments %}
     <a id="comments" class="anchor"></a>

--- a/source/_layouts/sdk/markdown.html
+++ b/source/_layouts/sdk/markdown.html
@@ -22,9 +22,6 @@ layout: sdk/master
     <div class="col-l-8">
       <h1 class="pagetitle">{{ page.title }}</h1>
       <div class="markdown markdown--staff">
-	      {% if page.platform_choice %}
-	      {% include platform-choice.html %}
-	      {% endif %}
         {{ content }}
       </div>
     </div>

--- a/source/_layouts/tutorials/tutorial.html
+++ b/source/_layouts/tutorials/tutorial.html
@@ -33,9 +33,6 @@ menu_section: tutorials
       </div>
       {% endif %}
       <div class="markdown markdown--staff">
-      {% if page.platform_choice %}
-      {% include platform-choice.html %}
-      {% endif %}
       {{ content }}
       </div>
     </div>

--- a/source/round/getting-started.md
+++ b/source/round/getting-started.md
@@ -21,7 +21,6 @@ layout: sdk/markdown
 permalink: /round/getting-started/
 generate_toc: true
 search_index: true
-platform_choice: true
 ---
 
 With the addition of Pebble Time Round to the Pebble hardware family, the Pebble
@@ -34,9 +33,7 @@ that are compatible with all hardware platforms. New graphics APIs and UI
 component behaviors assist with creating layouts ideally suited for both the
 rectangular and round display types.
 
-^LC^ [Get the SDK >{center,bg-lightblue,fg-white}](/sdk/download/?sdk={{ site.data.sdk.c.version }})
-
-^CP^ [Launch CloudPebble >{center,bg-lightblue,fg-white}]({{site.links.cloudpebble}})
+[Get the SDK >{center,bg-lightblue,fg-white}](/sdk/download/?sdk={{ site.data.sdk.c.version }})
 
 ## New Resources
 
@@ -76,9 +73,7 @@ concept. They are listed below.
 
 **Time Dots**
 
-^LC^ [![time-dots >{pebble-screenshot,pebble-screenshot--time-round-silver-14}](/images/sdk/time-dots.png)]({{site.links.examples_org}}/time-dots/)
-
-^CP^ [![time-dots >{pebble-screenshot,pebble-screenshot--time-round-silver-14}](/images/sdk/time-dots.png)]({{site.links.cloudpebble}}ide/import/github/pebble-examples/time-dots/)
+[![time-dots >{pebble-screenshot,pebble-screenshot--time-round-silver-14}](/images/sdk/time-dots.png)]({{site.links.examples_org}}/time-dots/)
 
 **Concentricity**
 {% screenshot_viewer %}
@@ -96,6 +91,4 @@ concept. They are listed below.
 
 **ContentIndicator Demo**
 
-^LC^ [![content-indicator-demo >{pebble-screenshot,pebble-screenshot--time-round-silver-14}](/images/sdk/content-indicator-demo.png)]({{site.links.examples_org}}/content-indicator-demo/)
-
-^CP^ [![content-indicator-demo >{pebble-screenshot,pebble-screenshot--time-round-silver-14}](/images/sdk/content-indicator-demo.png)]({{site.links.cloudpebble}}ide/import/github/pebble-examples/content-indicator-demo/)
+[![content-indicator-demo >{pebble-screenshot,pebble-screenshot--time-round-silver-14}](/images/sdk/content-indicator-demo.png)]({{site.links.examples_org}}/content-indicator-demo/)

--- a/source/sdk4/getting-started.md
+++ b/source/sdk4/getting-started.md
@@ -19,7 +19,6 @@ description: |
 layout: sdk/markdown
 permalink: /sdk4/getting-started/
 search_index: true
-platform_choice: true
 ---
 
 Pebble SDK 4 is now available for developers who are interested in using the
@@ -29,12 +28,11 @@ guides listed below to help familiarize themselves with the new functionality.
 
 ## Getting Started
 
-{% platform local %}
 #### Mac OS X (Homebrew)
+
 ```bash
 $ brew update && brew upgrade pebble-sdk && pebble sdk install latest
 ````
-
 
 #### Mac OS X (Manual)
 1. Download the
@@ -51,11 +49,6 @@ Linux users should install the SDK manually using the instructions below:
 
 2. Install the SDK by following the
    [manual installation instructions](/sdk/install/linux/).
-{% endplatform %}
-
-{% platform cloudpebble %}
-<a href="{{site.links.cloudpebble}}" class="btn btn--fg-white btn--bg-lightblue">Launch CloudPebble</a>
-{% endplatform %}
 
 ## Blog Posts
 

--- a/source/tutorials/advanced/vector-animations.md
+++ b/source/tutorials/advanced/vector-animations.md
@@ -22,7 +22,6 @@ description: |
   How to use vector images in icons and animations.
 permalink: /tutorials/advanced/vector-animations/
 generate_toc: true
-platform_choice: true
 platforms:
   - basalt
   - chalk
@@ -152,11 +151,7 @@ weather apps.
 
 ## Getting Started
 
-^CP^ Begin a new [CloudPebble]({{ site.links.cloudpebble }}) project using the
-blank template and add code only to push an initial ``Window``, such as the
-example below:
-
-^LC^ Begin a new project using `pebble new-project` and create a simple app that
+Begin a new project using `pebble new-project` and create a simple app that
 pushes a blank ``Window``, such as the example below:
 
 ```c
@@ -200,17 +195,11 @@ int main() {
 For this tutorial, use the example
 [`weather_image.pdc`](/assets/other/weather_image.pdc) file provided.
 
-^CP^ Add the PDC file as a project resource using the 'Add new' under
-'Resources' on the left-hand side of the CloudPebble editor, with an
-'Identifier' of `WEATHER_IMAGE`, and a type of 'raw binary blob'. The file is
-assumed to be called `weather_image.pdc`.
-
-^LC^ Add the PDC file to your project resources in `package.json` as shown
+Add the PDC file to your project resources in `package.json` as shown
 below. Set the 'name' field to `WEATHER_IMAGE`, and the 'type' field to `raw`.
 The file is assumed to be called `weather_image.pdc`:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "media": [
   {
     "type": "raw",
@@ -218,19 +207,11 @@ The file is assumed to be called `weather_image.pdc`:
     "file": "weather_image.pdc"
   }
 ]
-{% endhighlight %}
-</div>
 
-^LC^ Drawing a Pebble Draw Command image is just as simple as drawing a normal PNG
+Drawing a Pebble Draw Command image is just as simple as drawing a normal PNG
 image to a graphics context, requiring only one draw call. First, load the
 `.pdc` file from resources, for example with the `name` defined as
 `WEATHER_IMAGE`, as shown below.
-
-^CP^ Drawing a Pebble Draw Command image is just as simple as drawing a normal
-PNG image to a graphics context, requiring only one draw call. First, load the
-`.pdc` file from resources, for example with the 'Identifier' defined as
-`WEATHER_IMAGE`. This will be available in code as `RESOURCE_ID_WEATHER_IMAGE`,
-as shown below.
 
 Declare a pointer of type ``GDrawCommandImage`` at the top of the file:
 
@@ -323,15 +304,11 @@ For this tutorial, use the example
 
 Begin a new app, with a C file containing the [template](#getting-started) provided above.
 
-^CP^ Next, add the file as a `raw` resource in the same way as for a PDC image,
-for example with an `Identifier` specified as `CLOCK_SEQUENCE`.
-
-^LC^ Next, add the file as a `raw` resource in the same way as for a PDC image,
+Next, add the file as a `raw` resource in the same way as for a PDC image,
 for example with the `name` field specified in `package.json` as
 `CLOCK_SEQUENCE`.
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "media": [
   {
     "type": "raw",
@@ -339,8 +316,7 @@ for example with the `name` field specified in `package.json` as
     "file": "clock_sequence.pdc"
   }
 ]
-{% endhighlight %}
-</div>
+```
 
 Load the PDCS in your app by first declaring a ``GDrawCommandSequence`` pointer:
 

--- a/source/tutorials/js-watchface-tutorial/part1.md
+++ b/source/tutorials/js-watchface-tutorial/part1.md
@@ -22,7 +22,6 @@ description: A guide to making a new Pebble watchface with Rocky.js
 permalink: /tutorials/js-watchface-tutorial/part1/
 menu_section: tutorials
 generate_toc: true
-platform_choice: true
 ---
 
 {% include tutorials/rocky-js-warning.html %}
@@ -43,19 +42,6 @@ and finally create an analog clock which looks just like this:
 
 ## First Steps
 
-^CP^ Go to [CloudPebble]({{ site.links.cloudpebble }}) and click
-'Get Started' to log in using your Pebble account, or create a new one if you do
-not already have one. Once you've logged in, click 'Create' to create a new
-project. Give your project a suitable name, such as 'Tutorial 1' and set the
-'Project Type' as 'Rocky.js (beta)'. This will create a completely empty
-project, so before you continue, you will need to click the 'Add New' button in
-the left menu to create a new Rocky.js JavaScript file.
-
-^CP^ Next we need to change our project from a watchapp to a watchface. Click
-'Settings' in the left menu, then change the 'APP KIND' to 'watchface'.
-
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown {} %}
 If you haven't already, head over the [SDK Page](/sdk/install/) to learn how to
 download and install the latest version of the Pebble Tool, and the latest SDK.
 
@@ -68,8 +54,6 @@ $ pebble new-project --rocky helloworld
 
 This will create a new folder called `helloworld` and populate it with the basic
 structure required for a basic Rocky.js application.
-{% endmarkdown %}
-</div>
 
 
 ## Watchface Basics
@@ -79,10 +63,7 @@ a regular interval (typically once a minute, or when specific events occur). By
 minimizing the frequency that the screen is updated, we help to conserve
 battery life on the watch.
 
-^CP^ We'll start by editing the `index.js` file that we created earlier. Click
-on the filename in the left menu and it will load, ready for editing.
-
-^LC^ The main entry point for the watchface is `/src/rocky/index.js`, so we'll
+The main entry point for the watchface is `/src/rocky/index.js`, so we'll
 start by editing this file.
 
 The very first thing we must do is include the Rocky.js library, which gives us
@@ -140,10 +121,7 @@ things:
 - Display the current time, using the width and height to determine the center
 point of the screen.
 
-^CP^ To create our minimal watchface which displays the current time, let's
-replace the contents of our `index.js` file with the following code:
-
-^LC^ To create our minimal watchface which displays the current time, let's
+To create our minimal watchface which displays the current time, let's
 replace the contents of `/src/rocky/index.js` with the following code:
 
 ```js
@@ -184,14 +162,6 @@ rocky.on('minutechange', function(event) {
 
 ## First Compilation and Installation
 
-^CP^ To compile the watchface, click the 'PLAY' button on the right hand side
-of the screen. This will save your file, compile the project and launch your
-watchface in the emulator.
-
-^CP^ Click the 'VIEW LOGS' button.
-
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown {} %}
 To compile the watchface, make sure you have saved your project files, then
 run the following command from the project's root directory:
 
@@ -212,8 +182,6 @@ Now install the watchapp and view the logs on the emulator by running:
 ```nc|text
 $ pebble install --logs --emulator basalt
 ```
-{% endmarkdown %}
-</div>
 
 ## Congratulations!
 
@@ -443,16 +411,9 @@ rocky.on('minutechange', function(event) {
 Once you've added your logging statements, rebuild the application and view the
 logs:
 
-^CP^ Click the 'PLAY' button on the right hand side of the screen, then click
-the 'VIEW LOGS' button.
-
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown {} %}
 ```nc|text
 $ pebble build && pebble install --emulator basalt --logs
 ```
-{% endmarkdown %}
-</div>
 
 If you find that one of your logging statements hasn't appeared in the log
 output, it probably means there is an issue in the preceding code.

--- a/source/tutorials/js-watchface-tutorial/part2.md
+++ b/source/tutorials/js-watchface-tutorial/part2.md
@@ -22,7 +22,6 @@ description: A guide to adding web content to a JavaScript watchface
 permalink: /tutorials/js-watchface-tutorial/part2/
 menu_section: tutorials
 generate_toc: true
-platform_choice: true
 ---
 
 {% include tutorials/rocky-js-warning.html %}
@@ -43,12 +42,7 @@ the Pebble.
 
 ## First Steps
 
-^CP^ The first thing we'll need to do is add a new JavaScript file to the
-project we created in [Part 1](/tutorials/js-watchface-tutorial/part1). Click
-'Add New' in the left menu, set the filename to `index.js` and the 'TARGET' to
-'PebbleKit JS'.
-
-^LC^ The first thing we'll need to do is edit a file from the project we
+The first thing we'll need to do is edit a file from the project we
 created in [Part 1](/tutorials/js-watchface-tutorial/part1). The file is
 called `/src/pkjs/index.js` and it is the entry point for the `pkjs` portion
 of the application.
@@ -126,16 +120,10 @@ Our `pkjs` component can access to the location of the user's smartphone. The
 Rocky.js component cannot access location information directly, it must request
 it from `pkjs`.
 
-^CP^ In order to use this functionality, you must change your project settings
-in CloudPebble. Click 'SETTINGS' in the left menu, then tick 'USES LOCATION'.
-
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown {} %}
 In order to use this functionality, your application must include the
 `location` flag in the
 [`pebble.capabilities`](/guides/tools-and-resources/app-metadata/)
 array of your `package.json` file.
-
 
 ```js
 // file: package.json
@@ -145,8 +133,6 @@ array of your `package.json` file.
   }
 // ...
 ```
-{% endmarkdown %}
-</div>
 
 Once we've added the `location` flag, we can access GPS coordinates using the
 [Geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation).

--- a/source/tutorials/watchface-tutorial/part1.md
+++ b/source/tutorials/watchface-tutorial/part1.md
@@ -22,7 +22,6 @@ description: A guide to making a new Pebble watchface with the Pebble C API
 permalink: /tutorials/watchface-tutorial/part1/
 menu_section: tutorials
 generate_toc: true
-platform_choice: true
 ---
 
 In this tutorial we'll cover the basics of writing a simple watchface with
@@ -48,41 +47,26 @@ new basic watchface looking something like this:
 
 So, let's get started!
 
-^CP^ Go to [CloudPebble]({{ site.links.cloudpebble }}) and click 'Get Started'
-to log in using your Pebble account, or create a new one if you do not already
-have one. Next, click 'Create' to create a new project. Give your project a
-suitable name, such as 'Tutorial 1' and leave the 'Project Type' as 'Pebble C
-SDK', with a 'Template' of 'Empty project', as we will be starting from scratch
-to help maximize your understanding as we go.
-
-^LC^ Before you can start the tutorial you will need to have the Pebble SDK
+Before you can start the tutorial you will need to have the Pebble SDK
 installed. If you haven't done this yet, go to our [download page](/sdk) to grab
 the SDK and follow the instructions to install it on your machine. Once you've
 done that you can come back here and carry on where you left off.
 
-^LC^ Once you have installed the SDK, navigate to a directory of your choosing
+Once you have installed the SDK, navigate to a directory of your choosing
 and run `pebble new-project watchface` (where 'watchface' is the name of your
 new project) to start a new project and set up all the relevant files.
 
-^CP^ Click 'Create' and you will see the main CloudPebble project screen. The
-left menu shows all the relevant links you will need to create your watchface.
-Click on 'Settings' and you will see the name you just supplied, along with
-several other options. As we are creating a watchface, change the 'App Kind' to
-'Watchface'.
-
-^LC^ In an SDK project, all the information about how an app is configured (its
+In an SDK project, all the information about how an app is configured (its
 name, author, capabilities and resource listings etc) is stored in a file in the
 project root directory called `package.json`. Since this project will be a
 watchface, you will need to modify the `watchapp` object in this file to reflect
 this:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "watchapp": {
   "watchface": true
 }
-{% endhighlight %}
-</div>
+```
 
 The main difference between the two kinds are that watchfaces serve as the
 default display on the watch, with the Up and Down buttons allowing use of the
@@ -91,18 +75,12 @@ behavior (Back and Select are also not available to watchfaces). In contrast,
 watchapps are launched from the Pebble system menu. These have more capabilities
 such as button clicks and menu elements, but we will come to those later.
 
-^CP^ Finally, set your 'Company Name' and we can start to write some code!
-
-^LC^ Finally, set a value for `companyName` and we can start to write some code!
+Finally, set a value for `companyName` and we can start to write some code!
 
 
 ## Watchface Basics
 
-^CP^ Create the first source file by clicking 'Add New' on the left menu,
-selecting 'C file' as the type and choosing a suitable name such as 'main.c'.
-Click 'Create' and you will be shown the main editor screen.
-
-^LC^ Our first source file is already created for you by the `pebble` command
+Our first source file is already created for you by the `pebble` command
 line tool and lives in the project's `src` directory. By default, this file
 contains sample code which you can safely remove, since we will be starting from
 scratch. Alternatively, you can avoid this by using the `--simple` flag when
@@ -123,10 +101,7 @@ make the task of managing memory allocation and deallocation as simple as
 possible. Additionally, `main()` also calls ``app_event_loop()``, which lets the
 watchapp wait for system events until it exits.
 
-^CP^ The recommended structure is shown below, and you can use it as the basis
-for your own watchface file by copying it into CloudPebble:
-
-^LC^ The recommended structure is shown below, and you can use it as the basis
+The recommended structure is shown below, and you can use it as the basis
 for your main C file:
 
 ```c
@@ -215,14 +190,7 @@ valid after each iterative change, so let's do this now.
 
 ## First Compilation and Installation
 
-^CP^ To compile the watchface, make sure you have saved your C file by clicking
-the 'Save' icon on the right of the editor screen and then proceed to the
-'Compilation' screen by clicking the appropriate link on the left of the screen.
-Click 'Run Build' to start the compilation process and wait for the result.
-Hopefully the status should become 'Succeeded', meaning the code is valid and
-can be run on the watch.
-
-^LC^ To compile the watchface, make sure you have saved your project files and
+To compile the watchface, make sure you have saved your project files and
 then run `pebble build` from the project's root directory. The installable
 `.pbw` file will be deposited in the `build` directory. After a successful
 compile you will see a message reading `'build' finished successfully`. If there
@@ -233,18 +201,12 @@ In order to install your watchface on your Pebble, first
 [setup the Pebble Developer Connection](/guides/tools-and-resources/developer-connection/).
 Make sure you are using the latest version of the Pebble app.
 
-^CP^ Click 'Install and Run' and wait for the app to install.
-
-^LC^ Install the watchapp by running `pebble install`, supplying your phone's IP
+Install the watchapp by running `pebble install`, supplying your phone's IP
 address with the `--phone` flag. For example: `pebble install
 --phone 192.168.1.78`.
 
-<div class="platform-specific" data-sdk-platform="local">
-{% markdown {} %}
 > Instead of using the --phone flag every time you install, set the PEBBLE_PHONE environment variable:
 > `export PEBBLE_PHONE=192.168.1.78` and simply use `pebble install`.
-{% endmarkdown %}
-</div>
 
 Congratulations! You should see that you have a new item in the watchface menu,
 but it is entirely blank!
@@ -266,10 +228,7 @@ Let's change that with the next stage towards a basic watchface - the
 
 ## Showing Some Text
 
-^CP^ Navigate back to the CloudPebble code editor and open your main C file to
-continue adding code.
-
-^LC^ Re-open your main C file to continue adding code.
+Re-open your main C file to continue adding code.
 
 The best way to show some text on a watchface or watchapp
 is to use a ``TextLayer`` element. The first step in doing this is to follow a
@@ -332,10 +291,7 @@ static void main_window_unload(Window *window) {
 }
 ```
 
-^CP^ This completes the setup of the basic watchface layout. If you return to
-'Compilation' and install a new build, you should now see the following:
-
-^LC^ This completes the setup of the basic watchface layout. If you run `pebble
+This completes the setup of the basic watchface layout. If you run `pebble
 build && pebble install` (with your phone's IP address) for the new build, you
 should now see the following:
 
@@ -463,9 +419,7 @@ watchface! To do this we:
 If you have problems with your code, check it against the sample source code
 provided using the button below.
 
-^CP^ [Edit in CloudPebble >{center,bg-lightblue,fg-white}]({{ site.links.cloudpebble }}ide/gist/9b9d50b990d742a3ae34)
-
-^LC^ [View Source Code >{center,bg-lightblue,fg-white}](https://gist.github.com/9b9d50b990d742a3ae34)
+[View Source Code >{center,bg-lightblue,fg-white}](https://gist.github.com/9b9d50b990d742a3ae34)
 
 ## What's Next?
 

--- a/source/tutorials/watchface-tutorial/part2.md
+++ b/source/tutorials/watchface-tutorial/part2.md
@@ -21,7 +21,6 @@ title: Customizing Your Watchface
 description: A guide to personalizing your new Pebble watchface
 permalink: /tutorials/watchface-tutorial/part2/
 generate_toc: true
-platform_choice: true
 ---
 
 In the previous page of the tutorial, you learned how to create a new Pebble
@@ -58,9 +57,6 @@ project or create a new one, using the code from that project's main `.c` file
 as a starting template. For reference, that should look
 [something like this](https://gist.github.com/pebble-gists/9b9d50b990d742a3ae34).
 
-^CP^ You can create a new CloudPebble project from this template by
-[clicking here]({{ site.links.cloudpebble }}ide/gist/9b9d50b990d742a3ae34).
-
 The result of the first part should look something like this - a basic time
 display:
 
@@ -79,22 +75,13 @@ Let's improve it!
 
 ## Adding a Custom Font
 
-^CP^ To add a custom font resource to use for the time display ``TextLayer``,
-click 'Add New' on the left of the CloudPebble editor. Set the 'Resource Type'
-to 'TrueType font' and upload a font file. Choose an 'Identifier', which is the
-value we will use to refer to the font resource in the `.c` file. This must end
-with the desired font size, which must be small enough to show a wide time such
-as '23:50' in the ``TextLayer``. If it does not fit, you can always return here
-to try another size. Click save and the font will be added to your project.
-
-^LC^ App resources (fonts and images etc.) are managed in the `package.json`
+App resources (fonts and images etc.) are managed in the `package.json`
 file in the project's root directory, as detailed in
 [*App Resources*](/guides/app-resources/). All image files and fonts must 
 reside in subfolders of the `/resources` folder of your project. Below is an 
 example entry in the `media` array:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "media": [
   {
     "type": "font",
@@ -103,10 +90,9 @@ example entry in the `media` array:
     "compatibility":"2.7"
   }
 ]
-{% endhighlight %}
-</div>
+```
 
-^LC^ In the example above, we would place our `perfect-dos-vga.ttf` file in the
+In the example above, we would place our `perfect-dos-vga.ttf` file in the
 `/resources/fonts/` folder of our project.
 
 A custom font file must be a
@@ -152,12 +138,7 @@ void main_window_unload() {
 }
 ```
 
-^CP^ After re-compiling and re-installing (either by using the green 'Play'
-button to the top right of the CloudPebble editor, or by clicking 'Run Build'
-and 'Install and Run' on the 'Compilation' screen), the watchface should feature
-a much more interesting font.
-
-^LC^ After re-compiling and re-installing with `pebble build && pebble install`,
+After re-compiling and re-installing with `pebble build && pebble install`,
 the watchface should feature a much more interesting font.
 
 An example screenshot is shown below:
@@ -187,24 +168,17 @@ structure before being displayed using a ``BitmapLayer`` element. These two
 behave in a similar fashion to ``GFont`` and ``TextLayer``, so let's get
 started.
 
-^CP^ The first step is the same as using a custom font; import the bitmap into
-CloudPebble as a resource by clicking 'Add New' next to 'Resources' on the left
-of the CloudPebble project screen. Ensure the 'Resource Type' is 'Bitmap image',
-choose an identifier for the resource and upload your file.
-
-^LC^ You add a bitmap to the `package.json` file in the
+You add a bitmap to the `package.json` file in the
 [same way](/guides/app-resources/fonts) as a font, except the new `media` array
 object will have a `type` of `bitmap`. Below is an example:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 {
   "type": "bitmap",
   "name": "IMAGE_BACKGROUND",
   "file": "images/background.png"
 }
-{% endhighlight %}
-</div>
+```
 
 As before, here is an example bitmap we have created for you to use, which looks
 like this:
@@ -287,9 +261,7 @@ available for `strftime()`!)
 As with last time, you can compare your own code to the example source code
 using the button below.
 
-^CP^ [Edit in CloudPebble >{center,bg-lightblue,fg-white}]({{ site.links.cloudpebble }}ide/gist/d216d9e0b840ed296539)
-
-^LC^ [View Source Code >{center,bg-lightblue,fg-white}](https://gist.github.com/d216d9e0b840ed296539)
+[View Source Code >{center,bg-lightblue,fg-white}](https://gist.github.com/d216d9e0b840ed296539)
 
 
 ## What's Next?

--- a/source/tutorials/watchface-tutorial/part3.md
+++ b/source/tutorials/watchface-tutorial/part3.md
@@ -21,7 +21,6 @@ title: Adding Web Content
 description: A guide to adding web-based content your Pebble watchface
 permalink: /tutorials/watchface-tutorial/part3/
 generate_toc: true
-platform_choice: true
 ---
 
 In the previous tutorial parts, we created a simple watchface to tell the time
@@ -57,8 +56,6 @@ project or create a new one, using the code from that project's main `.c` file
 as a starting template. For reference, that should look 
 [something like this](https://gist.github.com/pebble-gists/d216d9e0b840ed296539). 
 
-^CP^ You can create a new CloudPebble project from this template by 
-[clicking here]({{ site.links.cloudpebble }}ide/gist/d216d9e0b840ed296539).
 
 ## Preparing the Watchface Layout
 
@@ -89,17 +86,11 @@ text_layer_set_text(s_weather_layer, "Loading...");
 
 We will be using the same font as the time display, but at a reduced font size.
 
-^CP^ To do this, we return to our uploaded font resource and click 'Another
-Font. The second font that appears below should be given an 'Identifier' with
-`_20` at the end, signifying we now want font size 20 (suitable for the example
-font provided).
-
-^LC^ You can add another font in `package.json` by duplicating the first font's
+You can add another font in `package.json` by duplicating the first font's
 entry in the `media` array and changing the font size indicated in the `name`
 field to `_20` or similar. Below is an example showing both fonts:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "media": [
   {
     "type":"font",
@@ -114,8 +105,7 @@ field to `_20` or similar. Below is an example showing both fonts:
     "compatibility": "2.7"
   },
 ]
-{% endhighlight %}
-</div>
+```
 
 Now we will load and apply that font as we did last time, beginning with a new
 ``GFont`` declared at the top of the file:
@@ -236,11 +226,7 @@ app_message_open(inbox_size, outbox_size);
 The weather data itself will be downloaded by the JavaScript component of the
 watchface, and runs on the connected phone whenever the watchface is opened. 
 
-^CP^ To begin using PebbleKit JS, click 'Add New' in the CloudPebble editor,
-next to 'Source Files'. Select 'JavaScript file' and choose a file name.
-CloudPebble allows any normally valid file name, such as `weather.js`.
-
-^LC^ To begin using PebbleKit JS, add a new file to your project at 
+To begin using PebbleKit JS, add a new file to your project at 
 `src/pkjs/index.js` to contain your JavaScript code.
 
 To get off to a quick start, we will provide a basic template for using the
@@ -269,25 +255,18 @@ Pebble.addEventListener('appmessage',
 
 After compiling and installing the watchface, open the app logs.
 
-^CP^ Click the 'View Logs' button on the confirmation dialogue or the
-'Compilation' screen if it was already dismissed.
-
-^LC^ You can listen for app logs by running `pebble logs`, supplying your
+You can listen for app logs by running `pebble logs`, supplying your
 phone's IP address with the `--phone` switch. For example: 
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```
 pebble logs --phone 192.168.1.78
-{% endhighlight %}
-</div>
+```
 
-^LC^ You can also combine these two commands into one: 
+You can also combine these two commands into one: 
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```
 pebble install --logs --phone 192.168.1.78
-{% endhighlight %}
-</div>
+```
 
 You should see a message matching that set to appear using `console.log()` in
 the JS console in the snippet above! This is where any information sent using
@@ -307,19 +286,13 @@ our JS file:
 3. Send the information we want from the XHR request response to the watch for
    display on our watchface.
 
-^CP^ Firstly, go to 'Settings' and check the 'Uses Location' box at the bottom
-of the page. This will allow the watchapp to access the phone's location
-services.
-
-^LC^ You will need to add `location` to the `capabilities` array in the
+You will need to add `location` to the `capabilities` array in the
 `package.json` file. This will allow the watchapp to access the phone's location
 services. This is shown in the code segment below:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "capabilities": ["location"]
-{% endhighlight %}
-</div>
+```
 
 The next step is simple to perform, and is shown in full below. The method we
 are using requires two other functions to use as callbacks for the success and
@@ -436,20 +409,15 @@ The final JS step is to send the weather data back to the watch. To do this we m
 pick some appmessage keys to send back. Since we want to display the temperature
 and current conditions, we'll create one key for each of those.
 
-^CP^ Firstly, go to the 'Settings' screen, find the 'PebbleKit JS Message Keys'
-section and enter some names, like "TEMPERATURE" and "CONDITIONS":
-
-^LC^ You can add your ``AppMessage`` keys in the `messageKeys` object in
+You can add your ``AppMessage`` keys in the `messageKeys` object in
 `package.json` as shown below for the example keys:
 
-<div class="platform-specific" data-sdk-platform="local">
-{% highlight {} %}
+```json
 "messageKeys": [
   "TEMPERATURE",
   "CONDITIONS",
 ]
-{% endhighlight %}
-</div>
+```
 
 To send the data, we call `Pebble.sendAppMessage()` after assembling the weather
 info variables `temperature` and `conditions` into a dictionary. We can
@@ -548,11 +516,7 @@ that looks similar to the one shown below:
 }
 {% endscreenshot_viewer %}
 
-^CP^ Remember, if the text is too large for the screen, you can reduce the font
-size in the 'Resources' section of the CloudPebble editor. Don't forget to
-change the constants in the `.c` file to match the new 'Identifier'.
-
-^LC^ Remember, if the text is too large for the screen, you can reduce the font
+Remember, if the text is too large for the screen, you can reduce the font
 size in `package.json` for that resource's entry in the `media` array. Don't
 forget to change the constants in the `.c` file to match the new resource's
 `name`.
@@ -600,9 +564,7 @@ services to display data and control these services.
 As usual, you can compare your code to the example code provided using the button
 below.
 
-^CP^ [Edit in CloudPebble >{center,bg-lightblue,fg-white}]({{ site.links.cloudpebble }}ide/gist/216e6d5a0f0bd2328509)
-
-^LC^ [View Source Code >{center,bg-lightblue,fg-white}](https://gist.github.com/216e6d5a0f0bd2328509)
+[View Source Code >{center,bg-lightblue,fg-white}](https://gist.github.com/216e6d5a0f0bd2328509)
 
 
 ## What's Next?

--- a/source/tutorials/watchface-tutorial/part5.md
+++ b/source/tutorials/watchface-tutorial/part5.md
@@ -22,7 +22,6 @@ description: |
   How to add bluetooth connection alerts to your watchface.
 permalink: /tutorials/watchface-tutorial/part5/
 generate_toc: true
-platform_choice: true
 ---
 
 The final popular watchface addition explored in this tutorial series
@@ -61,15 +60,6 @@ hidden when reconnected. Save the image below for use in this project:
 
 <img style="background-color: #CCCCCC;" src="/assets/images/tutorials/intermediate/bt-icon.png"</img>
 
-
-{% platform cloudpebble %}
-Add this icon to your project by clicking 'Add New' under 'Resources' in
-the left hand side of the editor. Specify the 'Resource Type' as 'Bitmap Image',
-upload the file for the 'File' field. Give it an 'Identifier' such as
-`IMAGE_BT_ICON` before clicking 'Save'.
-{% endplatform %}
-
-{% platform local %}
 Add this icon to your project by copying the above icon image to the `resources`
 project directory, and adding a new JSON object to the `media` array in
 `package.json` such as the following:
@@ -81,7 +71,6 @@ project directory, and adding a new JSON object to the `media` array in
   "file": "bt-icon.png"
 },
 ```
-{% endplatform %}
 
 This icon will be loaded into the app as a ``GBitmap`` for display in a
 ``BitmapLayer`` above the time display. Declare both of these as pointers at the
@@ -146,10 +135,7 @@ twice.
 
 ![bt >{pebble-screenshot,pebble-screenshot--steel-black}](/images/tutorials/intermediate/bt.png)
 
-^CP^ You can create a new CloudPebble project from the completed project by
-[clicking here]({{ site.links.cloudpebble }}ide/gist/ddd15cbe8b0986fda407).
-
-^LC^ You can see the finished project source code in
+You can see the finished project source code in
 [this GitHub Gist](https://gist.github.com/pebble-gists/ddd15cbe8b0986fda407).
 
 

--- a/spec/pebble_markdown_parser_spec.rb
+++ b/spec/pebble_markdown_parser_spec.rb
@@ -149,20 +149,6 @@ describe Jekyll::Converters::Markdown::PebbleMarkdownParser, '#convert' do
     end
   end
 
-  describe 'paragraphs' do
-    it 'adds a data attribute for sdk platforms' do
-      doc = md2doc("^LC^ Local SDK instructions\n\n^CP^CloudPebble instructions\n\nRegular old paragraph")
-      expect(doc.at_css('p:nth-child(1)').attribute('data-sdk-platform').value).to eql('local')
-      expect(doc.at_css('p:nth-child(1)').content).to eql('Local SDK instructions')
-      expect(doc.at_css('p:nth-child(1)')['class']).to include('platform-specific')
-      expect(doc.at_css('p:nth-child(2)').attribute('data-sdk-platform').value).to eql('cloudpebble')
-      expect(doc.at_css('p:nth-child(2)').content).to eql('CloudPebble instructions')
-      expect(doc.at_css('p:nth-child(2)')['class']).to include('platform-specific')
-      expect(doc.at_css('p:nth-child(3)').attribute('data-sdk-platform')).to eql(nil)
-      expect(doc.at_css('p:nth-child(3)').content).to eql('Regular old paragraph')
-    end
-  end
-
   describe 'block code' do
     it 'processes code blocks with Pygments' do
       doc = md2doc("```\nvar a = 1;\n```")


### PR DESCRIPTION
Removing the CloudPebble vs SDK specific block in guides and tutorials - AFAIK it's SDK only from now on (but there were many good times :cry:)

* Remove `platform_choice: true` in YAML metadata
* Remove content shown/hidden with `^LC^` and `^CP^`
* Remove content shown/hidden with the `platform-specific` `div` class.

There may be more things, but this is a start!