### PR TITLE
Redirect links to old copy of site to new, subpath-less versions

### DIFF
--- a/plugins/generator_redirects.rb
+++ b/plugins/generator_redirects.rb
@@ -13,22 +13,34 @@
 # limitations under the License.
 
 module Jekyll
-
   class GeneratorRedirects < Generator
-
     priority :lowest
 
-    def initialize(config)
-    end
+    def initialize(config) end
 
     def generate(site)
       @site = site
       site.data['redirects'].each do |redirect|
-        if is_infinite_redirect?(redirect[0], redirect[1])
-          Jekyll.logger.warn "Redirect Warning:", "Skipping redirect of #{redirect[0]} to #{redirect[1]}"
+        if infinite_redirect?(redirect[0], redirect[1])
+          Jekyll.logger.warn 'Redirect Warning:', "Skipping redirect of #{redirect[0]} to #{redirect[1]}"
           next
         end
-        @site.pages << RedirectPage.new(@site, @site.source, File.dirname(redirect[0]), File.basename(redirect[0]), redirect[1])
+        @site.pages <<
+          RedirectPage.new(@site, @site.source, File.dirname(redirect[0]), File.basename(redirect[0]), redirect[1])
+      end
+
+      # Generate redirects for the old URLs under the /developer.pebble.com/ subpath to new, subpath-less location
+      site.pages.each do |page|
+        next if page.url.start_with?('/developer.pebble.com/')
+        next if page.url.start_with?('/assets/')
+
+        if page.url.end_with?('/')
+          @site.pages <<
+            RedirectPage.new(@site, @site.source, "/developer.pebble.com#{page.url}", 'index.html', page.url)
+        else
+          @site.pages <<
+            RedirectPage.new(@site, @site.source, File.dirname("/developer.pebble.com#{page.url}"), File.basename(page.url), page.url)
+        end
       end
     end
 
@@ -36,27 +48,25 @@ module Jekyll
 
     # Returns true if the redirect pair (from, to) will cause an infinite
     # redirect.
-    def is_infinite_redirect?(from, to)
+    def infinite_redirect?(from, to)
       return true if from == to
-      return true if File.basename(from) == 'index.html' && File.dirname(from) == File.dirname(to + 'index.html')
+
+      return true if File.basename(from) == 'index.html' && File.dirname(from) == File.dirname("#{to}index.html")
+
       false
     end
-
   end
 
   class RedirectPage < Page
-
     def initialize(site, base, dir, name, redirect_to)
       @site = site
       @base = base
       @dir = dir
       @name = name.empty? ? 'index.html' : name
 
-      self.process(@name)
-      self.read_yaml(File.join(base, '_layouts', 'utils'), 'redirect_permanent.html')
-      self.data['redirect_to'] = redirect_to
+      process(@name)
+      read_yaml(File.join(base, '_layouts', 'utils'), 'redirect_permanent.html')
+      data['redirect_to'] = redirect_to
     end
-
   end
-
 end

--- a/plugins/generator_redirects.rb
+++ b/plugins/generator_redirects.rb
@@ -66,7 +66,7 @@ module Jekyll
 
       process(@name)
       read_yaml(File.join(base, '_layouts', 'utils'), 'redirect_permanent.html')
-      data['redirect_to'] = redirect_to
+      data['redirect_to'] = redirect_to.delete_suffix('index.html')
     end
   end
 end

--- a/plugins/generator_redirects.rb
+++ b/plugins/generator_redirects.rb
@@ -30,18 +30,8 @@ module Jekyll
       end
 
       # Generate redirects for the old URLs under the /developer.pebble.com/ subpath to new, subpath-less location
-      site.pages.each do |page|
-        next if page.url.start_with?('/developer.pebble.com/')
-        next if page.url.start_with?('/assets/')
-
-        if page.url.end_with?('/')
-          @site.pages <<
-            RedirectPage.new(@site, @site.source, "/developer.pebble.com#{page.url}", 'index.html', page.url)
-        else
-          @site.pages <<
-            RedirectPage.new(@site, @site.source, File.dirname("/developer.pebble.com#{page.url}"), File.basename(page.url), page.url)
-        end
-      end
+      site.pages.dup.reject { |page| page.url.start_with?('/assets/') }.each(&method(:create_old_path_redirect))
+      site.collections.flat_map { |collection| collection[1].docs }.each(&method(:create_old_path_redirect))
     end
 
     private
@@ -54,6 +44,16 @@ module Jekyll
       return true if File.basename(from) == 'index.html' && File.dirname(from) == File.dirname("#{to}index.html")
 
       false
+    end
+
+    def create_old_path_redirect(page)
+      if page.url.end_with?('/')
+        @site.pages <<
+          RedirectPage.new(@site, @site.source, "/developer.pebble.com#{page.url}", 'index.html', page.url)
+      else
+        @site.pages <<
+          RedirectPage.new(@site, @site.source, File.dirname("/developer.pebble.com#{page.url}"), File.basename(page.url), page.url)
+      end
     end
   end
 

--- a/source/_layouts/utils/redirect_permanent.html
+++ b/source/_layouts/utils/redirect_permanent.html
@@ -27,5 +27,21 @@ new ones.
 {% capture redirect_url %}{{ page.redirect_to }}{% endcapture %}
 {% endif %}
 
-<meta http-equiv="refresh" content="0; url={{ redirect_url }}">
-<link rel="canonical" href="{{ redirect_url }}" />
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="refresh" content="0; url={{ redirect_url }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="canonical" href="{{ redirect_url }}" />
+    <title>Redirecting to: {{ redirect_url }}</title>
+  </head>
+  <body>
+    <p>
+      Redirecting to {{ redirect_url }}...
+    </p>
+    <p>
+      <a href="{{ redirect_url }}">Click here</a> if the page does not load.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Modifies the redirect generator to create a redirect for every page under `/developer.pebble.com/`, stripping that part out of the URL. Also includes some changes to the redirect template to hopefully get better SEO and convince search engines to flush out the old URLs in favour of the new ones.

Fixes #28.