### PR TITLE
Update emulator arrow keys list

### DIFF
--- a/source/_guides/tools-and-resources/pebble-tool.md
+++ b/source/_guides/tools-and-resources/pebble-tool.md
@@ -154,12 +154,10 @@ The Pebble physical buttons are emulated with the following mapping:
 
 | Button | Key |
 |--------|-----|
-| Back | `Q` |
-| Up | `W` |
-| Select | `S` |
-| Down | `X` |
-
-On some systems the arrow keys may also be supported.
+| Back | `Q`, left arrow |
+| Up | `W`, up arrow |
+| Select | `S`, right arrow |
+| Down | `X`, down arrow |
 
 
 ## Pebble Timeline in the Emulator


### PR DESCRIPTION
These keys are more reliably available than arrow keys (if arrow keys ever work or ceased to at some point in the past).