### PR TITLE
gemfile: use gem.coop as gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source 'https://rubygems.org'
+source 'https://gem.coop'
 ruby file: '.ruby-version'
 
 gem 'slugize', '>= 0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: https://rubygems.org/
+  remote: https://gem.coop/
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)


### PR DESCRIPTION
Seems like https://gem.coop has emerged as the successor to RubyGems after the whole recent mess.