### PR TITLE
Hardware information: Add some information about flint and emery

### DIFF
--- a/source/_includes/hardware-platforms.html
+++ b/source/_includes/hardware-platforms.html
@@ -159,9 +159,9 @@ limitations under the License.
         <tr>
             <td>Lens Material</td>
             <td>Polycarbonate</td>
-            <td>Gorilla Glass<br /><em>(curved)</em></td>
+            <td colspan="2">Gorilla Glass<br /><em>(curved)</em></td>
             <td colspan="2">Gorilla Glass<br /><em>(flat)</em></td>
-            <td colspan="2">Hardened Glass<br /><em>(flat)</em></td>
+            <td>Hardened Glass<br /><em>(flat)</em></td>
         </tr>
         <tr>
             <td>Charging Port</td>
@@ -172,7 +172,8 @@ limitations under the License.
         </tr>
         <tr>
             <td>Battery Life</td>
-            <td colspan="2">~7 days</td>
+            <td>~7 days</td>
+            <td>~7 days (Pebble Time), ~10 days (Pebble Time Steel)</td>
             <td>~2 days</td>
             <td>~7 days</td>
             <td colspan="2">~30 days</td>
@@ -183,7 +184,8 @@ limitations under the License.
             <td>3 ATM<sup>*2</sup><br /><em>(30 m)</em></td>
             <td>None<br /><em>(Splash Resistant)</em></td>
             <td>3 ATM<sup>*2</sup><br /><em>(30 m)</em></td>
-            <td colspan="2">TBD<br /><em>(target IPX8)</em></td>
+            <td>20 m<br /></td>
+            <td>TBD<br /><em>(target IPX8)</em></td>
         </tr>
         <thead>
             <tr>


### PR DESCRIPTION
Information about resource and RAM sizes for flint and emery come from Core Devices' Pebble SDK 4.9.77 build output. Flint's water resistance rating comes from the back of the watch (alpha units and production units are consistent on this), and flint's cover glass is the same as diorite's cover glass.