### PR TITLE
Make sense of the sidebar links

### DIFF
--- a/source/_layouts/community.html
+++ b/source/_layouts/community.html
@@ -13,6 +13,7 @@ sidebar_only: false
         <ul>
           <li class="section-menu__subitem{% if page.community_event == 'retreat-2015' %} active{% endif %}"><a href="/community/events/developer-retreat-2015/"><span>Developer Retreat 2015</span></a></li>
           <li class="section-menu__subitem{% if page.community_event == 'retreat-2014' %} active{% endif %}"><a href="/community/events/developer-retreat-2014/"><span>Developer Retreat 2014</span></a></li>
+          <li class="section-menu__subitem{% if page.community_event == 'retreat-2013' %} active{% endif %}"><a href="/community/events/developer-retreat-2013/"><span>Developer Retreat 2013</span></a></li>
         </ul>
       </li>
       <li class="section-menu__item{% if page.menu_subsection == 'online' %} active{% endif %}"><a href="/community/online/">Online Communities</a></li>

--- a/source/_layouts/more.html
+++ b/source/_layouts/more.html
@@ -24,7 +24,6 @@ sidebar_only: false
     </div>
     <ul>
       <li class="section-menu__item{% if page.menu_subsection == 'inspiration' %} active{% endif %}"><a href="/inspiration/">App Inspiration</a></li>
-      <li class="section-menu__item{% if layout.menu_subsection == 'examples' or page.menu_subsection == 'examples' %} active{% endif %}"><a href="/examples/">Examples</a></li>
       <li class="section-menu__item{% if page.menu_subsection == 'contact' %} active{% endif %}"><a href="/contact/">Contact</a></li>
       <li class="section-menu__item{% if page.menu_subsection == 'faqs' %} active{% endif %}"><a href="/faqs/">FAQs</a></li>
       <li class="section-menu__item{% if page.menu_subsection == 'legal' %} open{% endif %}"><a href="/legal/">Legal</a>

--- a/source/community/events/developer-retreat-2013/index.html
+++ b/source/community/events/developer-retreat-2013/index.html
@@ -1,5 +1,8 @@
 ---
-layout: default
+layout: community
+title: Developer Retreat 2013
+menu_subsection: events
+community_event: retreat-2013
 ---
 
 <div class="container main-container">


### PR DESCRIPTION
* Developer retreat was missing and had the wrong layout applies
* The examples link was a duplicate of the exposed top-level Examples option