### PR TITLE
Fix bad custom animation example

### DIFF
--- a/source/_guides/graphics-and-animations/animations.md
+++ b/source/_guides/graphics-and-animations/animations.md
@@ -175,6 +175,13 @@ static void implementation_update(Animation *animation,
 static void implementation_teardown(Animation *animation) {
   APP_LOG(APP_LOG_LEVEL_INFO, "Animation finished!");
 }
+
+// This needs to exist while the event loop runs
+static const AnimationImplementation s_implementation = {
+  .setup = implementation_setup,
+  .update = implementation_update,
+  .teardown = implementation_teardown
+};
 ```
 
 Once these are in place, create a new ``Animation`` , specifying the new custom
@@ -187,12 +194,7 @@ animation_set_delay(animation, 1000);
 animation_set_duration(animation, 1000);
 
 // Create the AnimationImplementation
-const AnimationImplementation implementation = {
-  .setup = implementation_setup,
-  .update = implementation_update,
-  .teardown = implementation_teardown
-};
-animation_set_implementation(animation, &implementation);
+animation_set_implementation(animation, &s_implementation);
 
 // Play the Animation
 animation_schedule(animation);


### PR DESCRIPTION
The custom animation example suggests that a stack-allocated AnimationImplementation variable can be used, but this is incorrect. The variable is not copied and so must remain valid while the animation runs.

For brevity, I have used a static qualifier to give the variable global lifespan without making it an explicit global variable.

I have also added a note about the lifetime of the AnimationImplementation variable.

The API documentation is not clear, and following this example led me to a crashing app. I am seemingly not the only one that has had this happen. See https://stackoverflow.com/questions/35661791/pebble-how-to-create-a-custom-animation for the same problem (though it's not clear if they also based their code on the example).