### PR TITLE
Add npm as a dependency for macOS

### DIFF
--- a/source/sdk/index.md
+++ b/source/sdk/index.md
@@ -30,7 +30,7 @@ scripts:
 You'll need Python 3.10 or above, not the MacOS default installation of 3.9. To install a newer version of Python using [Homebrew](https://brew.sh/), run:
 
 ```bash
-brew install python
+brew install python node
 ```
 
 #### Ubuntu


### PR DESCRIPTION
npm is a dependency, and it is listed as such for Ubuntu, but not for macOS.

I could not get the pebble SDK installed until I had npm. Since we are being directed to use homebrew, and it can install npm, do that.