### PR TITLE
Remove the note about new information being added when the preview of SDK 4 comes out

### DIFF
--- a/source/_guides/tools-and-resources/hardware-information.md
+++ b/source/_guides/tools-and-resources/hardware-information.md
@@ -32,6 +32,3 @@ The table below details the differences between hardware platforms:
 See
 {% guide_link best-practices/building-for-every-pebble#available-defines-and-macros "Available Defines and Macros" %}
 for a complete list of compile-time defines available.
-
-**NOTE:** We'll be updating the "Building for Every Pebble Guide" and "Available
-Defines and Macros" list when we release the first preview version of SDK 4.0.


### PR DESCRIPTION
That happened about 9 years ago :p

I'm not actually sure if that information was ever added, but the note about how it's going to be added has no place on that page today, in my opinion