### PR TITLE
Specify Asterix battery life as of the current firmware alongside the theoretical number

### DIFF
--- a/source/_includes/hardware-platforms.html
+++ b/source/_includes/hardware-platforms.html
@@ -176,7 +176,7 @@ limitations under the License.
             <td>~7 days (Pebble Time), ~10 days (Pebble Time Steel)</td>
             <td>~2 days</td>
             <td>~7 days</td>
-            <td colspan="2">~30 days</td>
+            <td colspan="2">~14 days as of PebbleOS v4.9.91<br /><em>(~30 days theoretical)</em></td>
         </tr>
         <tr>
             <td>Water Resistance<sup>*3</sup></td>


### PR DESCRIPTION
The current hardware info page quotes only ~30 days for Pebble 2 Duo, despite actual battery life with current firmware being ~14 days.  I've edited the text to specify the 14 day battery life on the current firmware alongside the theoretical 30 days that may one day be acheived. 