### PR TITLE
Add clarifications for battery life and waterproofing diminishing as the watch ages or after repairs

### DIFF
--- a/source/_includes/hardware-platforms.html
+++ b/source/_includes/hardware-platforms.html
@@ -171,7 +171,7 @@ limitations under the License.
             <td colspan="2">Power only</td>
         </tr>
         <tr>
-            <td>Battery Life</td>
+            <td>Battery Life<sup>*4</sup></td>
             <td>~7 days</td>
             <td>~7 days (Pebble Time), ~10 days (Pebble Time Steel)</td>
             <td>~2 days</td>
@@ -179,7 +179,7 @@ limitations under the License.
             <td colspan="2">~30 days</td>
         </tr>
         <tr>
-            <td>Water Resistance</td>
+            <td>Water Resistance<sup>*3</sup></td>
             <td>5 ATM<sup>*2</sup><br /><em>(50 m)</em></td>
             <td>3 ATM<sup>*2</sup><br /><em>(30 m)</em></td>
             <td>None<br /><em>(Splash Resistant)</em></td>
@@ -210,4 +210,6 @@ limitations under the License.
             diving.</li>
         <br>
     </ul>
+    <p><sup>*3</sup>Rated waterproofing is applicable to new, sealed hardware. Age or repairs may compromise water resistance.</p>
+    <p><sup>*4</sup>Rated battery life is applicable to new hardware in typical usage conditions. Heavy use or use of power intensive apps and watchfaces may lead to a lower battery life. Battery life will reduce as the watch ages. Aftermarket replacement batteries may have a lower capacity.</p>
 </div>


### PR DESCRIPTION
The hardware info page currently quotes the water resistance as per the original specifications when the watches were new. While this isn't incorrect, I worry that it may lead users to incorrectly expect old hardware to maintain it's factory water resistance after so many years.

In a similar, albeit less serious vein, battery life will also likely have reduced as watches have aged, and replacement batteries can't be assumed to have the same battery life as originals. While this will likely be obvious to most people, I feel like if water resistance is going to be clarified, battery life might as well also be. 