### PR TITLE
Add dependencies for Fedora

### DIFF
--- a/source/sdk/index.md
+++ b/source/sdk/index.md
@@ -50,7 +50,7 @@ sudo apt install libsdl1.2debian libfdt1
 #### Fedora
 
 ```bash
-sudo dnf install python3-pip nodejs npm SDL-devel dtc
+sudo dnf install python3-pip nodejs SDL-devel dtc
 ```
 
 #### Windows


### PR DESCRIPTION
After a bit of back and forth, I got the SDK running on Fedora 42. Turns out Ubuntu's `libsdl1.2debian` is covered by `SDL-devel` and `libfdt1` is covered by `dtc`.

Works!