### PR TITLE
Add a new version of the GIMP color palette

### DIFF
--- a/source/_guides/app-resources/images.md
+++ b/source/_guides/app-resources/images.md
@@ -55,7 +55,9 @@ are available below. Use these when creating color image resources:
 
 * [Illustrator `.ai`](/assets/other/pebble_colors_64.ai)
 
-* [GIMP `.pal`](/assets/other/pebble_colors_64.pal)
+* [GIMP `.gpl`](/assets/other/pebble_colors_64.gpl)
+
+* [GIMP `.pal`](/assets/other/pebble_colors_64.pal) (old RIFF format)
 
 * [ImageMagick `.gif`](/assets/other/pebble_colors_64.gif)
 

--- a/source/assets/other/pebble_colors_64.gpl
+++ b/source/assets/other/pebble_colors_64.gpl
@@ -1,0 +1,68 @@
+GIMP Palette
+Name: Pebble
+Columns: 16
+#
+  0   0  85	Oxford Blue
+  0   0 170	Duke Blue
+  0   0 255	Blue
+  0  85   0	Dark Green (X11)
+  0  85  85	Midnight Green (Eagle Green)
+  0  85 170	Cobalt Blue
+  0  85 255	Blue Moon
+  0 170   0	Islamic Green
+  0 170  85	Jaeger Green
+  0 170 170	Tiffany Blue
+  0 170 255	Vivid Cerulean
+  0 255   0	Green
+  0 255  85	Malachite
+  0 255 170	Medium Spring Green
+  0 255 255	Cyan
+ 85   0   0	Bulgarian Rose
+ 85   0  85	Imperial Purple
+ 85   0 170	Indigo (Web)
+ 85   0 255	Electric Ultramarine
+ 85  85   0	Army Green
+ 85  85  85	Dark Gray
+ 85  85 170	Liberty
+ 85  85 255	Very Light Blue
+ 85 170   0	Kelly Green
+ 85 170  85	May Green
+ 85 170 170	Cadet Blue
+ 85 170 255	Picton Blue
+ 85 255   0	Bright Green
+ 85 255  85	Screamin' Green
+ 85 255 170	Medium Aquamarine
+ 85 255 255	Electric Blue
+170   0   0	Dark Candy Apple Red
+170   0  85	Jazzberry Jam
+170   0 170	Purple
+170   0 255	Vivid Violet
+170  85   0	Windsor Tan
+170  85  85	Rose Vale
+170  85 170	Purpureus
+170  85 255	Lavender Indigo
+170 170   0	Limerick
+170 170  85	Brass
+170 170 170	Light Gray
+170 170 255	Baby Blue Eyes
+170 255   0	Spring Bud
+170 255  85	Inchworm
+170 255 170	Mint Green
+170 255 255	Celeste
+255   0   0	Red
+255   0  85	Folly
+255   0 170	Fashion Magenta
+255   0 255	Magenta
+255  85   0	Orange
+255  85  85	Sunset Orange
+255  85 170	Brilliant Rose
+255  85 255	Shocking Pink (Crayola)
+255 170   0	Chrome Yellow
+255 170  85	Rajah
+255 170 170	Melon
+255 170 255	Rich Brilliant Lavender
+255 255   0	Yellow
+255 255  85	Icterine
+255 255 170	Pastel Yellow
+255 255 255	White
+  0   0   0	Black


### PR DESCRIPTION
The currently available GIMP palette file is for older versions of GIMP (in RIFF palette format); newer versions of GIMP can’t even read it. This PR adds a new version of the palette (while preserving the old).

Signed-off-by: Gergely Polonkai <gergely@polonkai.eu>
